### PR TITLE
Scrollytelling tweaks: zoom, blur, and slide improvements

### DIFF
--- a/scrolling-slides/src/components/scrolling-slides/ScrollingSlide.tsx
+++ b/scrolling-slides/src/components/scrolling-slides/ScrollingSlide.tsx
@@ -82,12 +82,18 @@ const SLIDE_COMPONENT: Record<SlideType, React.ComponentType<BaseSlideProps>> = 
   zoom: ZoomSlide,
 };
 
-const ScrollingSlide = ({ children = [], type, defaultSpeed, overrideTransition, hostRef }: Props) => {
+const ScrollingSlide = ({
+  children = [],
+  type,
+  defaultSpeed,
+  overrideTransition,
+  hostRef,
+}: Props) => {
   if (!type) type = 'scroll';
 
   // Resolve TransitionValue or plain string into slide type + settings
   const tv: TransitionValue =
-    typeof type === 'string' ? { primary: type } : (type || { primary: 'scroll' });
+    typeof type === 'string' ? { primary: type } : type || { primary: 'scroll' };
   const resolved = resolveTransition(tv.primary || 'scroll', tv.effects);
   const slideType = (resolved.type || 'scroll') as SlideType;
   const defaultSettings = resolved.settings || {};

--- a/scrolling-slides/src/components/scrolling-slides/ScrollingSlide.tsx
+++ b/scrolling-slides/src/components/scrolling-slides/ScrollingSlide.tsx
@@ -115,7 +115,6 @@ const ScrollingSlide = ({
 
   const ref = useRef<HTMLDivElement>(null);
   const timeline = useViewTimeline(ref as React.RefObject<HTMLElement>, disabled);
-  const size = useSize(ref);
   useSlideEditMode(hostRef, children, timeline);
 
   useEffect(() => {
@@ -239,7 +238,7 @@ registerVevComponent(ScrollingSlide, {
       type: 'select',
       name: 'defaultSpeed',
       title: 'Default speed',
-      initialValue: 'linear',
+      initialValue: 'cubic-bezier(0.7, 0, 0.3, 1)',
       options: {
         display: 'dropdown',
         items: SPEED_OPTIONS,

--- a/scrolling-slides/src/components/scrolling-slides/slide/CubeSlide.tsx
+++ b/scrolling-slides/src/components/scrolling-slides/slide/CubeSlide.tsx
@@ -16,32 +16,63 @@ export function CubeSlide({
   const transitionCount = slideCount - 1;
   const { ownsIn, ownsOut } = transition;
 
-  const phaseSettings = transition.transitionIn?.settings ?? transition.transitionOut?.settings;
+  const inSettings = transition.transitionIn?.settings;
+  const outSettings = transition.transitionOut?.settings;
   const inSpeed = transition.transitionIn?.speed || 'linear';
   const outSpeed = transition.transitionOut?.speed || 'linear';
 
-  const isVertical = phaseSettings?.cubeDirection === 'vertical';
-  const half = isVertical ? '50cqb' : '50cqi';
-  const axis = isVertical ? 'rotateX' : 'rotateY';
-  const inAngle = isVertical ? '-90deg' : '90deg';
-  const outAngle = isVertical ? '90deg' : '-90deg';
+  // Resolve direction per-phase so overrides only affect their own gap
+  const isVerticalIn = inSettings?.cubeDirection === 'vertical';
+  const isVerticalOut = outSettings?.cubeDirection === 'vertical';
 
-  const cubeTransform = (angle: string) =>
-    `translateZ(-${half}) ${axis}(${angle}) translateZ(${half})`;
+  // Check if in and out use different axes (e.g. horizontal default + vertical override)
+  const mixedAxes = isVerticalIn !== isVerticalOut
+    && ownsIn && ownsOut && index > 0 && index < transitionCount;
 
-  // Build keyframes with per-segment easing so adjacent slides stay in sync
-  const keyframes: Keyframe[] = [];
-  if (ownsIn && index > 0) {
-    keyframes.push({ transform: cubeTransform(inAngle), easing: inSpeed });
+  let keyframes: Keyframe[];
+  let initialTransform: string;
+
+  if (mixedAxes) {
+    // Combined transform with both axes for consistent keyframe interpolation
+    const cubeTransform = (xRot: string, yRot: string) =>
+      `translateZ(-50cqb) rotateX(${xRot}) translateZ(50cqb) translateZ(-50cqi) rotateY(${yRot}) translateZ(50cqi)`;
+
+    const inXRot = isVerticalIn ? '-90deg' : '0deg';
+    const inYRot = isVerticalIn ? '0deg' : '90deg';
+    const outXRot = isVerticalOut ? '90deg' : '0deg';
+    const outYRot = isVerticalOut ? '0deg' : '-90deg';
+
+    keyframes = [
+      { transform: cubeTransform(inXRot, inYRot), easing: inSpeed },
+      { transform: cubeTransform('0deg', '0deg'), easing: outSpeed },
+      { transform: cubeTransform(outXRot, outYRot) },
+    ];
+    initialTransform = cubeTransform(inXRot, inYRot);
+  } else {
+    // Single axis — original behavior
+    const isVertical = ownsIn && index > 0 ? isVerticalIn : isVerticalOut;
+    const half = isVertical ? '50cqb' : '50cqi';
+    const axis = isVertical ? 'rotateX' : 'rotateY';
+    const inAngle = isVertical ? '-90deg' : '90deg';
+    const outAngle = isVertical ? '90deg' : '-90deg';
+
+    const cubeTransform = (angle: string) =>
+      `translateZ(-${half}) ${axis}(${angle}) translateZ(${half})`;
+
+    keyframes = [];
+    if (ownsIn && index > 0) {
+      keyframes.push({ transform: cubeTransform(inAngle), easing: inSpeed });
+    }
+    keyframes.push({
+      transform: cubeTransform('0deg'),
+      ...(ownsOut && index < transitionCount ? { easing: outSpeed } : {}),
+    });
+    if (ownsOut && index < transitionCount) {
+      keyframes.push({ transform: cubeTransform(outAngle) });
+    }
+    if (keyframes.length === 1) keyframes.push(keyframes[0]);
+    initialTransform = cubeTransform(inAngle);
   }
-  keyframes.push({
-    transform: cubeTransform('0deg'),
-    ...(ownsOut && index < transitionCount ? { easing: outSpeed } : {}),
-  });
-  if (ownsOut && index < transitionCount) {
-    keyframes.push({ transform: cubeTransform(outAngle) });
-  }
-  if (keyframes.length === 1) keyframes.push(keyframes[0]);
 
   // Compute offset range from owned phases
   let fromOffset = ownsIn && index > 0 ? (index - 1) / transitionCount : index / transitionCount;
@@ -74,7 +105,7 @@ export function CubeSlide({
         ...style,
         backfaceVisibility: 'hidden',
         ...(!disabled && ownsIn && index > 0
-          ? { transform: cubeTransform(inAngle) }
+          ? { transform: initialTransform }
           : {}),
       }}
     />

--- a/scrolling-slides/src/components/scrolling-slides/slide/FlipSlide.tsx
+++ b/scrolling-slides/src/components/scrolling-slides/slide/FlipSlide.tsx
@@ -16,26 +16,35 @@ export function FlipSlide({
   const transitionCount = slideCount - 1;
   const { ownsIn, ownsOut } = transition;
 
-  const phaseSettings = transition.transitionIn?.settings ?? transition.transitionOut?.settings;
+  const inSettings = transition.transitionIn?.settings;
+  const outSettings = transition.transitionOut?.settings;
   const inSpeed = transition.transitionIn?.speed || 'linear';
   const outSpeed = transition.transitionOut?.speed || 'linear';
 
-  const isVertical = phaseSettings?.flipDirection === 'vertical';
-  const axis = isVertical ? 'rotateX' : 'rotateY';
-  const inAngle = isVertical ? '180deg' : '-180deg';
-  const outAngle = isVertical ? '-180deg' : '180deg';
+  // Resolve direction per-phase so overrides only affect their own gap
+  const isVerticalIn = inSettings?.flipDirection === 'vertical';
+  const isVerticalOut = outSettings?.flipDirection === 'vertical';
+
+  // Use both axes in all keyframes for consistent interpolation
+  const flipTransform = (x: string, y: string) =>
+    `perspective(1200px) rotateX(${x}) rotateY(${y})`;
+
+  const inX = isVerticalIn ? '180deg' : '0deg';
+  const inY = isVerticalIn ? '0deg' : '-180deg';
+  const outX = isVerticalOut ? '-180deg' : '0deg';
+  const outY = isVerticalOut ? '0deg' : '180deg';
 
   // Build keyframes with per-segment easing so adjacent slides stay in sync
   const keyframes: Keyframe[] = [];
   if (ownsIn && index > 0) {
-    keyframes.push({ transform: `perspective(1200px) ${axis}(${inAngle})`, easing: inSpeed });
+    keyframes.push({ transform: flipTransform(inX, inY), easing: inSpeed });
   }
   keyframes.push({
-    transform: `perspective(1200px) ${axis}(0deg)`,
+    transform: flipTransform('0deg', '0deg'),
     ...(ownsOut && index < transitionCount ? { easing: outSpeed } : {}),
   });
   if (ownsOut && index < transitionCount) {
-    keyframes.push({ transform: `perspective(1200px) ${axis}(${outAngle})` });
+    keyframes.push({ transform: flipTransform(outX, outY) });
   }
   if (keyframes.length === 1) keyframes.push(keyframes[0]);
 
@@ -70,7 +79,7 @@ export function FlipSlide({
         ...style,
         backfaceVisibility: 'hidden',
         ...(!disabled && ownsIn && index > 0
-          ? { transform: `perspective(1200px) ${axis}(${inAngle})` }
+          ? { transform: flipTransform(inX, inY) }
           : {}),
       }}
     />

--- a/scrolling-slides/src/components/scrolling-slides/slide/MaskSlide.tsx
+++ b/scrolling-slides/src/components/scrolling-slides/slide/MaskSlide.tsx
@@ -2,20 +2,28 @@ import React from 'react';
 import { AnimatedSlide } from './AnimatedSlide';
 import { BaseSlideProps } from './BaseSlide';
 
-const MASK_KEYFRAMES = [
-  {
-    '--slide-offset': '0',
-  },
-  {
-    '--slide-offset': '1',
-  },
-];
-
 export function MaskSlide({ transition, ...rest }: BaseSlideProps) {
   const s = transition.transitionIn?.settings ?? transition.transitionOut?.settings;
   const clipPath =
     s?.maskShape ||
     'circle(calc(var(--slide-offset) * 150%) at calc(var(--mask-x) * 100%) calc(var(--mask-y) * 100%))';
+  const blur = s?.blur || 0;
+  const zoom = s?.scale || 0;
+  const zoomIn = 1 + zoom;
+
+  const keyframes: Keyframe[] = [
+    {
+      '--slide-offset': '0',
+      ...(blur ? { filter: `blur(${blur}px)` } : {}),
+      ...(zoom ? { scale: `${zoomIn}` } : {}),
+    },
+    {
+      '--slide-offset': '1',
+      ...(blur ? { filter: 'blur(0px)' } : {}),
+      ...(zoom ? { scale: '1' } : {}),
+    },
+  ];
+
   return (
     <AnimatedSlide
       {...rest}
@@ -27,7 +35,7 @@ export function MaskSlide({ transition, ...rest }: BaseSlideProps) {
         } as any
       }
       transition={transition}
-      keyframes={MASK_KEYFRAMES}
+      keyframes={keyframes}
     />
   );
 }

--- a/scrolling-slides/src/components/scrolling-slides/slide/RevealSlide.tsx
+++ b/scrolling-slides/src/components/scrolling-slides/slide/RevealSlide.tsx
@@ -2,26 +2,34 @@ import React from 'react';
 import { AnimatedSlide } from './AnimatedSlide';
 import { BaseSlideProps } from './BaseSlide';
 
-const REVEAL_KEYFRAMES = [
-  {
-    '--slide-offset': '0',
-  },
-  {
-    '--slide-offset': '1',
-  },
-];
-
 export function RevealSlide({ transition, ...rest }: BaseSlideProps) {
   const s = transition.transitionIn?.settings ?? transition.transitionOut?.settings;
   const direction =
     s?.revealDirection ||
     'polygon(0 0, calc(var(--slide-offset) * 100%) 0, calc(var(--slide-offset) * 100%) 100%, 0% 100%)';
+  const blur = s?.blur || 0;
+  const zoom = s?.scale || 0;
+  const zoomIn = 1 + zoom;
+
+  const keyframes: Keyframe[] = [
+    {
+      '--slide-offset': '0',
+      ...(blur ? { filter: `blur(${blur}px)` } : {}),
+      ...(zoom ? { scale: `${zoomIn}` } : {}),
+    },
+    {
+      '--slide-offset': '1',
+      ...(blur ? { filter: 'blur(0px)' } : {}),
+      ...(zoom ? { scale: '1' } : {}),
+    },
+  ];
+
   return (
     <AnimatedSlide
       {...rest}
       style={{ clipPath: direction } as any}
       transition={transition}
-      keyframes={REVEAL_KEYFRAMES}
+      keyframes={keyframes}
     />
   );
 }

--- a/scrolling-slides/src/components/scrolling-slides/slide/ScrollSlide.tsx
+++ b/scrolling-slides/src/components/scrolling-slides/slide/ScrollSlide.tsx
@@ -29,30 +29,44 @@ export function ScrollSlide({
   const hasIn = ownsIn && index > 0;
   const hasOut = ownsOut && index < transitionCount;
 
-  // Helper to build transform + filter strings
+  // Helpers
   const sc = zoomAmount > 0 ? `scale(${1 / (1 + zoomAmount)})` : '';
   const tfm = (translate: string, scaled: boolean) =>
     `translateX(${translate})${scaled && sc ? ` ${sc}` : ''}`;
-  const blur = (on: boolean) => (blurPx > 0 ? `blur(${on ? blurPx : 0}px)` : undefined);
+  const blurOn = blurPx > 0 ? { filter: `blur(${blurPx}px)` } : {};
+  const blurOff = blurPx > 0 ? { filter: 'blur(0px)' } : {};
 
   const keyframes: Keyframe[] = [];
 
   if (zoomAmount > 0) {
-    // Zoom effect: scale happens in the 20% edges, full size in the middle
+    // Zoom scroll: zoom happens in the 20% edges of each phase.
+    // Both in and out slides translate over the same middle 60% so they stay in sync.
+    //
+    // hasOut only:  [zoom-out 20%] [translate 60% w/ easing] [hold 20%]
+    // hasIn only:   [wait 20%]     [translate 60% w/ easing] [zoom-in 20%]
+    // hasIn+hasOut:  per half — same pattern scaled to 0-0.5 and 0.5-1
     if (hasIn && hasOut) {
-      keyframes.push({ transform: tfm(enterFrom, true), filter: blur(true), offset: 0, easing: inSpeed });
-      keyframes.push({ transform: tfm('0%', true), filter: blur(true), offset: 0.4 });
-      keyframes.push({ transform: tfm('0%', false), filter: blur(false), offset: 0.5, easing: outSpeed });
-      keyframes.push({ transform: tfm('0%', true), filter: blur(true), offset: 0.6 });
-      keyframes.push({ transform: tfm(exitTo, true), filter: blur(true), offset: 1 });
+      // In-half (offsets 0–0.5): wait, translate in, zoom in
+      keyframes.push({ transform: tfm(enterFrom, true), ...blurOn, offset: 0 });
+      keyframes.push({ transform: tfm(enterFrom, true), ...blurOn, offset: 0.1, easing: inSpeed });
+      keyframes.push({ transform: tfm('0%', true), ...blurOn, offset: 0.4 });
+      keyframes.push({ transform: tfm('0%', false), ...blurOff, offset: 0.5 });
+      // Out-half (offsets 0.5–1): zoom out, translate out, hold
+      keyframes.push({ transform: tfm('0%', true), ...blurOn, offset: 0.6, easing: outSpeed });
+      keyframes.push({ transform: tfm(exitTo, true), ...blurOn, offset: 0.9 });
+      keyframes.push({ transform: tfm(exitTo, true), ...blurOn, offset: 1 });
     } else if (hasIn) {
-      keyframes.push({ transform: tfm(enterFrom, true), filter: blur(true), offset: 0, easing: inSpeed });
-      keyframes.push({ transform: tfm('0%', true), filter: blur(true), offset: 0.8 });
-      keyframes.push({ transform: tfm('0%', false), filter: blur(false), offset: 1 });
+      // Wait while adjacent slide zooms out, then translate in, then zoom in
+      keyframes.push({ transform: tfm(enterFrom, true), ...blurOn, offset: 0 });
+      keyframes.push({ transform: tfm(enterFrom, true), ...blurOn, offset: 0.2, easing: inSpeed });
+      keyframes.push({ transform: tfm('0%', true), ...blurOn, offset: 0.8 });
+      keyframes.push({ transform: tfm('0%', false), ...blurOff, offset: 1 });
     } else if (hasOut) {
-      keyframes.push({ transform: tfm('0%', false), filter: blur(false), offset: 0, easing: outSpeed });
-      keyframes.push({ transform: tfm('0%', true), filter: blur(true), offset: 0.2 });
-      keyframes.push({ transform: tfm(exitTo, true), filter: blur(true), offset: 1 });
+      // Zoom out, then translate out, then hold while adjacent slide zooms in
+      keyframes.push({ transform: tfm('0%', false), ...blurOff, offset: 0 });
+      keyframes.push({ transform: tfm('0%', true), ...blurOn, offset: 0.2, easing: outSpeed });
+      keyframes.push({ transform: tfm(exitTo, true), ...blurOn, offset: 0.8 });
+      keyframes.push({ transform: tfm(exitTo, true), ...blurOn, offset: 1 });
     } else {
       keyframes.push({ transform: tfm('0%', false) });
       keyframes.push({ transform: tfm('0%', false) });
@@ -60,15 +74,15 @@ export function ScrollSlide({
   } else {
     // Simple scroll (with optional blur across full range)
     if (hasIn) {
-      keyframes.push({ transform: tfm(enterFrom, false), filter: blur(true), easing: inSpeed });
+      keyframes.push({ transform: tfm(enterFrom, false), ...blurOn, easing: inSpeed });
     }
     keyframes.push({
       transform: tfm('0%', false),
-      filter: blur(false),
+      ...blurOff,
       ...(hasOut ? { easing: outSpeed } : {}),
     });
     if (hasOut) {
-      keyframes.push({ transform: tfm(exitTo, false), filter: blur(true) });
+      keyframes.push({ transform: tfm(exitTo, false), ...blurOn });
     }
     if (keyframes.length === 1) keyframes.push(keyframes[0]);
   }

--- a/scrolling-slides/src/components/scrolling-slides/slide/ScrollSlide.tsx
+++ b/scrolling-slides/src/components/scrolling-slides/slide/ScrollSlide.tsx
@@ -14,7 +14,6 @@ export function ScrollSlide({
 }: BaseSlideProps) {
   const ref = useRef<HTMLDivElement>(null);
   const transitionCount = slideCount - 1;
-  const { ownsIn, ownsOut } = transition;
 
   const phaseSettings = transition.transitionIn?.settings ?? transition.transitionOut?.settings;
   const inSpeed = transition.transitionIn?.speed || 'linear';
@@ -23,85 +22,57 @@ export function ScrollSlide({
   const isReverse = !!phaseSettings?.reverse;
   const zoomAmount = typeof phaseSettings?.zoomScroll === 'number' ? phaseSettings.zoomScroll : 0;
   const blurPx = typeof phaseSettings?.blurScroll === 'number' ? phaseSettings.blurScroll : 0;
-  const enterFrom = isReverse ? '-100%' : '100%';
-  const exitTo = isReverse ? '100%' : '-100%';
+  const direction = isReverse ? -1 : 1;
 
-  const hasIn = ownsIn && index > 0;
-  const hasOut = ownsOut && index < transitionCount;
+  // Container-translate model: every slide runs across the full scroll range in
+  // perfect lockstep, as if a strip containing all slides were translating as a
+  // single unit. At timeline offset t, the virtual container is at
+  // translateX(-t*(N-1)*100%), so slide i sits at (i - t*(N-1))*100%.
+  //
+  // Keyframes are placed at each gap boundary k (offset = k/(N-1)). The easing
+  // between gaps is driven by the adjacent-gap speed we know about (inSpeed for
+  // gap index-1, outSpeed for gap index). Remote gaps fall back to linear, which
+  // is visually irrelevant because this slide is off-screen during those gaps.
+  const scaleStr = zoomAmount > 0 ? ` scale(${1 / (1 + zoomAmount)})` : '';
+  const blurOn = blurPx > 0 ? `blur(${blurPx}px)` : undefined;
+  const blurOff = blurPx > 0 ? 'blur(0px)' : undefined;
 
-  // Helpers
-  const sc = zoomAmount > 0 ? `scale(${1 / (1 + zoomAmount)})` : '';
-  const tfm = (translate: string, scaled: boolean) =>
-    `translateX(${translate})${scaled && sc ? ` ${sc}` : ''}`;
-  const blurOn = blurPx > 0 ? { filter: `blur(${blurPx}px)` } : {};
-  const blurOff = blurPx > 0 ? { filter: 'blur(0px)' } : {};
+  const buildKeyframe = (k: number): Keyframe => {
+    const offset = transitionCount === 0 ? 0 : k / transitionCount;
+    const translate = (index - k) * 100 * direction;
+    const centered = k === index;
+    const kf: Keyframe = {
+      transform: `translateX(${translate}%)${!centered ? scaleStr : ''}`,
+      offset,
+    };
+    if (blurPx > 0) kf.filter = centered ? blurOff : blurOn;
+    return kf;
+  };
 
   const keyframes: Keyframe[] = [];
-
-  if (zoomAmount > 0) {
-    // Zoom scroll: zoom happens in the 20% edges of each phase.
-    // Both in and out slides translate over the same middle 60% so they stay in sync.
-    //
-    // hasOut only:  [zoom-out 20%] [translate 60% w/ easing] [hold 20%]
-    // hasIn only:   [wait 20%]     [translate 60% w/ easing] [zoom-in 20%]
-    // hasIn+hasOut:  per half — same pattern scaled to 0-0.5 and 0.5-1
-    if (hasIn && hasOut) {
-      // In-half (offsets 0–0.5): wait, translate in, zoom in
-      keyframes.push({ transform: tfm(enterFrom, true), ...blurOn, offset: 0 });
-      keyframes.push({ transform: tfm(enterFrom, true), ...blurOn, offset: 0.1, easing: inSpeed });
-      keyframes.push({ transform: tfm('0%', true), ...blurOn, offset: 0.4 });
-      keyframes.push({ transform: tfm('0%', false), ...blurOff, offset: 0.5 });
-      // Out-half (offsets 0.5–1): zoom out, translate out, hold
-      keyframes.push({ transform: tfm('0%', true), ...blurOn, offset: 0.6, easing: outSpeed });
-      keyframes.push({ transform: tfm(exitTo, true), ...blurOn, offset: 0.9 });
-      keyframes.push({ transform: tfm(exitTo, true), ...blurOn, offset: 1 });
-    } else if (hasIn) {
-      // Wait while adjacent slide zooms out, then translate in, then zoom in
-      keyframes.push({ transform: tfm(enterFrom, true), ...blurOn, offset: 0 });
-      keyframes.push({ transform: tfm(enterFrom, true), ...blurOn, offset: 0.2, easing: inSpeed });
-      keyframes.push({ transform: tfm('0%', true), ...blurOn, offset: 0.8 });
-      keyframes.push({ transform: tfm('0%', false), ...blurOff, offset: 1 });
-    } else if (hasOut) {
-      // Zoom out, then translate out, then hold while adjacent slide zooms in
-      keyframes.push({ transform: tfm('0%', false), ...blurOff, offset: 0 });
-      keyframes.push({ transform: tfm('0%', true), ...blurOn, offset: 0.2, easing: outSpeed });
-      keyframes.push({ transform: tfm(exitTo, true), ...blurOn, offset: 0.8 });
-      keyframes.push({ transform: tfm(exitTo, true), ...blurOn, offset: 1 });
-    } else {
-      keyframes.push({ transform: tfm('0%', false) });
-      keyframes.push({ transform: tfm('0%', false) });
-    }
+  if (transitionCount === 0) {
+    const kf = buildKeyframe(0);
+    keyframes.push(kf, { ...kf });
   } else {
-    // Simple scroll (with optional blur across full range)
-    if (hasIn) {
-      keyframes.push({ transform: tfm(enterFrom, false), ...blurOn, easing: inSpeed });
+    for (let k = 0; k <= transitionCount; k++) {
+      const kf = buildKeyframe(k);
+      if (k < transitionCount) {
+        // Easing applies from this keyframe to the next. Use our own speeds at
+        // the gaps we "own" (adjacent to this slide); linear elsewhere.
+        kf.easing = k === index - 1 ? inSpeed : k === index ? outSpeed : 'linear';
+      }
+      keyframes.push(kf);
     }
-    keyframes.push({
-      transform: tfm('0%', false),
-      ...blurOff,
-      ...(hasOut ? { easing: outSpeed } : {}),
-    });
-    if (hasOut) {
-      keyframes.push({ transform: tfm(exitTo, false), ...blurOn });
-    }
-    if (keyframes.length === 1) keyframes.push(keyframes[0]);
   }
 
-  // Compute offset range from owned phases
-  let fromOffset = hasIn ? (index - 1) / transitionCount : index / transitionCount;
-  let toOffset = hasOut ? (index + 1) / transitionCount : index / transitionCount;
-  if (index === 0) fromOffset = 0;
-  if (index === transitionCount) toOffset = 1;
-  if (fromOffset === toOffset) toOffset = fromOffset;
+  useViewAnimation(ref, keyframes, timeline, selected || disabled, undefined, 0, 1);
 
-  useViewAnimation(ref, keyframes, timeline, selected || disabled, undefined, fromOffset, toOffset);
-
-  // Initial style before animation kicks in
+  // Initial inline style: position slide at its starting offset in the strip.
   const initialStyle: React.CSSProperties =
-    !disabled && hasIn
+    !disabled && transitionCount > 0
       ? {
-          transform: tfm(enterFrom, zoomAmount > 0),
-          ...(blurPx > 0 ? { filter: `blur(${blurPx}px)` } : {}),
+          transform: `translateX(${index * 100 * direction}%)${index !== 0 ? scaleStr : ''}`,
+          ...(blurPx > 0 && index !== 0 ? { filter: `blur(${blurPx}px)` } : {}),
         }
       : {};
 

--- a/scrolling-slides/src/components/scrolling-slides/slide/StackSlide.tsx
+++ b/scrolling-slides/src/components/scrolling-slides/slide/StackSlide.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { AnimatedSlide } from './AnimatedSlide';
 import { BaseSlideProps } from './BaseSlide';
 
-const KEYFRAMES: Record<string, Keyframe[]> = {
-  up: [{ transform: 'translateY(100%)' }, { transform: 'translateY(0%)' }],
-  down: [{ transform: 'translateY(-100%)' }, { transform: 'translateY(0%)' }],
-  left: [{ transform: 'translateX(100%)' }, { transform: 'translateX(0%)' }],
-  right: [{ transform: 'translateX(-100%)' }, { transform: 'translateX(0%)' }],
+const TRANSLATE: Record<string, [string, string]> = {
+  up: ['translateY(100%)', 'translateY(0%)'],
+  down: ['translateY(-100%)', 'translateY(0%)'],
+  left: ['translateX(100%)', 'translateX(0%)'],
+  right: ['translateX(-100%)', 'translateX(0%)'],
 };
 
 export function StackSlide({ transition, ...rest }: BaseSlideProps) {
@@ -15,11 +15,28 @@ export function StackSlide({ transition, ...rest }: BaseSlideProps) {
   let dir = s?.stackDirection || 'up';
   if (dir === 'horizontal') dir = 'left';
   if (dir === 'vertical') dir = 'up';
+
+  const blur = s?.blur || 0;
+  const zoom = s?.scale || 0;
+  const zoomIn = 1 + zoom;
+  const [tFrom, tTo] = TRANSLATE[dir] || TRANSLATE.up;
+
+  const keyframes: Keyframe[] = [
+    {
+      transform: `${tFrom}${zoom ? ` scale(${zoomIn})` : ''}`,
+      ...(blur ? { filter: `blur(${blur}px)` } : {}),
+    },
+    {
+      transform: tTo,
+      ...(blur ? { filter: 'blur(0px)' } : {}),
+    },
+  ];
+
   return (
     <AnimatedSlide
       {...rest}
       transition={transition}
-      keyframes={KEYFRAMES[dir] || KEYFRAMES.up}
+      keyframes={keyframes}
     />
   );
 }

--- a/scrolling-slides/src/hooks/use-effect-animations.ts
+++ b/scrolling-slides/src/hooks/use-effect-animations.ts
@@ -1,0 +1,243 @@
+import { RefObject } from 'react';
+import { useViewAnimation } from './use-view-animation';
+
+type TransitionPhase = {
+  type: string;
+  settings: Record<string, any>;
+  speed: string;
+};
+
+type SlideTransitionModel = {
+  transitionIn: TransitionPhase | null;
+  transitionOut: TransitionPhase | null;
+  ownsIn: boolean;
+  ownsOut: boolean;
+};
+
+/**
+ * Applies effect-layer animations (opacity, scale, filter) on a slide element.
+ * These run as separate WAAPI animations alongside the primary transition animation,
+ * targeting non-overlapping CSS properties.
+ */
+export function useEffectAnimations(
+  ref: RefObject<HTMLElement>,
+  index: number,
+  slideCount: number,
+  timeline: ViewTimeline | undefined,
+  disabled: boolean,
+  transition: SlideTransitionModel,
+) {
+  const transitionCount = slideCount - 1;
+  const settings = transition.transitionIn?.settings ?? transition.transitionOut?.settings ?? {};
+  const { ownsIn, ownsOut } = transition;
+  const inSpeed = transition.transitionIn?.speed || 'linear';
+  const outSpeed = transition.transitionOut?.speed || 'linear';
+
+  const hasFade = !!settings.fadeIn || !!settings.fadeOut || !!settings.fadeDirection;
+  const hasZoom = !!settings.scale;
+  const hasBlur = !!settings.blur;
+
+  // Compute standard offsets (same logic as AnimatedSlide)
+  const inFrom = (index - 1) / transitionCount;
+  const inTo = index / transitionCount;
+  const outFrom = index / transitionCount;
+  const outTo = (index + 1) / transitionCount;
+
+  // --- Fade (opacity) ---
+  const fadeKeyframes: Keyframe[] = [];
+  let fadeFrom = inFrom;
+  let fadeTo = inTo;
+  let fadeDisabled = disabled || !hasFade;
+
+  if (hasFade && !fadeDisabled) {
+    const isFadeOut = !!settings.fadeDirection;
+    const isFadeInOut = !!settings.fadeOut && (!!settings.fadeIn || isFadeOut);
+
+    if (isFadeInOut) {
+      // Both in and out: opacity 0 → 1 → 0
+      if (index === 0) {
+        // First slide: only fades out
+        fadeKeyframes.push({ opacity: '1', easing: outSpeed });
+        fadeKeyframes.push({ opacity: '0' });
+        fadeFrom = outFrom;
+        fadeTo = outTo;
+        fadeDisabled = !ownsOut;
+      } else if (index === transitionCount) {
+        // Last slide: only fades in
+        fadeKeyframes.push({ opacity: '0', easing: inSpeed });
+        fadeKeyframes.push({ opacity: '1' });
+        fadeDisabled = !ownsIn;
+      } else if (ownsIn && ownsOut) {
+        fadeKeyframes.push({ opacity: '0', easing: inSpeed });
+        fadeKeyframes.push({ opacity: '1', easing: outSpeed });
+        fadeKeyframes.push({ opacity: '0' });
+        fadeFrom = inFrom;
+        fadeTo = outTo;
+      } else if (ownsIn) {
+        fadeKeyframes.push({ opacity: '0', easing: inSpeed });
+        fadeKeyframes.push({ opacity: '1' });
+      } else if (ownsOut) {
+        fadeKeyframes.push({ opacity: '1', easing: outSpeed });
+        fadeKeyframes.push({ opacity: '0' });
+        fadeFrom = outFrom;
+        fadeTo = outTo;
+      } else {
+        fadeDisabled = true;
+      }
+    } else if (isFadeOut) {
+      // Fade out only (reverse: outgoing slide fades out)
+      if (index === slideCount - 1) {
+        fadeDisabled = true;
+      } else if (ownsOut) {
+        fadeKeyframes.push({ opacity: '1', easing: outSpeed });
+        fadeKeyframes.push({ opacity: '0' });
+        fadeFrom = outFrom;
+        fadeTo = outTo;
+      } else {
+        fadeDisabled = true;
+      }
+    } else {
+      // Fade in only
+      if (index === 0) {
+        fadeDisabled = true;
+      } else if (ownsIn) {
+        fadeKeyframes.push({ opacity: '0', easing: inSpeed });
+        fadeKeyframes.push({ opacity: '1' });
+      } else {
+        fadeDisabled = true;
+      }
+    }
+  }
+
+  if (fadeKeyframes.length === 1) fadeKeyframes.push(fadeKeyframes[0]);
+
+  useViewAnimation(
+    ref,
+    fadeKeyframes.length > 0 ? fadeKeyframes : [{ opacity: '1' }, { opacity: '1' }],
+    timeline,
+    fadeDisabled || fadeKeyframes.length === 0,
+    undefined,
+    fadeFrom,
+    fadeTo,
+  );
+
+  // --- Zoom (scale) ---
+  const zoom = settings.scale || 0;
+  const zoomIn = 1 + zoom;
+  const zoomOut = 1 / zoomIn;
+  const zoomKeyframes: Keyframe[] = [];
+  let zoomFrom = inFrom;
+  let zoomTo = inTo;
+  let zoomDisabled = disabled || !hasZoom;
+
+  if (hasZoom && !zoomDisabled) {
+    const isFadeOut = !!settings.fadeDirection;
+
+    if (isFadeOut) {
+      // Zoom out direction (outgoing gets smaller)
+      if (index === slideCount - 1) {
+        zoomDisabled = true;
+      } else if (ownsOut) {
+        zoomKeyframes.push({ scale: '1', easing: outSpeed });
+        zoomKeyframes.push({ scale: `${zoomOut}` });
+        zoomFrom = outFrom;
+        zoomTo = outTo;
+      } else {
+        zoomDisabled = true;
+      }
+    } else {
+      // Zoom in direction (incoming starts zoomed)
+      if (index === 0) {
+        zoomDisabled = true;
+      } else if (ownsIn) {
+        zoomKeyframes.push({ scale: `${zoomIn}`, easing: inSpeed });
+        zoomKeyframes.push({ scale: '1' });
+      } else {
+        zoomDisabled = true;
+      }
+    }
+  }
+
+  if (zoomKeyframes.length === 1) zoomKeyframes.push(zoomKeyframes[0]);
+
+  useViewAnimation(
+    ref,
+    zoomKeyframes.length > 0 ? zoomKeyframes : [{ scale: '1' }, { scale: '1' }],
+    timeline,
+    zoomDisabled || zoomKeyframes.length === 0,
+    undefined,
+    zoomFrom,
+    zoomTo,
+  );
+
+  // --- Filter (blur) ---
+  const blur = settings.blur || 0;
+  const filterKeyframes: Keyframe[] = [];
+  let filterFrom = inFrom;
+  let filterTo = inTo;
+  let filterDisabled = disabled || !hasBlur;
+
+  if (hasBlur && !filterDisabled) {
+    if (index === 0) {
+      // First slide: only blurs out
+      if (ownsOut) {
+        filterKeyframes.push({ filter: 'blur(0px)', easing: outSpeed });
+        filterKeyframes.push({ filter: `blur(${blur}px)` });
+        filterFrom = outFrom;
+        filterTo = outTo;
+      } else {
+        filterDisabled = true;
+      }
+    } else if (index === transitionCount) {
+      // Last slide: only blurs in
+      if (ownsIn) {
+        filterKeyframes.push({ filter: `blur(${blur}px)`, easing: inSpeed });
+        filterKeyframes.push({ filter: 'blur(0px)' });
+      } else {
+        filterDisabled = true;
+      }
+    } else if (ownsIn && ownsOut) {
+      filterKeyframes.push({ filter: `blur(${blur}px)`, easing: inSpeed });
+      filterKeyframes.push({ filter: 'blur(0px)', easing: outSpeed });
+      filterKeyframes.push({ filter: `blur(${blur}px)` });
+      filterFrom = inFrom;
+      filterTo = outTo;
+    } else if (ownsIn) {
+      filterKeyframes.push({ filter: `blur(${blur}px)`, easing: inSpeed });
+      filterKeyframes.push({ filter: 'blur(0px)' });
+    } else if (ownsOut) {
+      filterKeyframes.push({ filter: 'blur(0px)', easing: outSpeed });
+      filterKeyframes.push({ filter: `blur(${blur}px)` });
+      filterFrom = outFrom;
+      filterTo = outTo;
+    } else {
+      filterDisabled = true;
+    }
+  }
+
+  if (filterKeyframes.length === 1) filterKeyframes.push(filterKeyframes[0]);
+
+  useViewAnimation(
+    ref,
+    filterKeyframes.length > 0 ? filterKeyframes : [{ filter: 'none' }, { filter: 'none' }],
+    timeline,
+    filterDisabled || filterKeyframes.length === 0,
+    undefined,
+    filterFrom,
+    filterTo,
+  );
+
+  // Return initial styles for effects (applied before animation starts)
+  const initialStyle: React.CSSProperties = {};
+  if (hasFade && !fadeDisabled && index !== 0 && !settings.fadeDirection) {
+    initialStyle.opacity = 0;
+  }
+  if (hasZoom && !zoomDisabled && index !== 0 && !settings.fadeDirection) {
+    (initialStyle as any).scale = `${zoomIn}`;
+  }
+  if (hasBlur && !filterDisabled && index !== 0) {
+    initialStyle.filter = `blur(${blur}px)`;
+  }
+
+  return initialStyle;
+}

--- a/scrolling-slides/src/hooks/use-slide-edit-mode.ts
+++ b/scrolling-slides/src/hooks/use-slide-edit-mode.ts
@@ -164,9 +164,26 @@ export function useSlideEditMode(
       }, SCROLL_DEBOUNCE);
     };
 
+    const handleResize = () => {
+      if (isScrollingRef.current) return;
+      const index = children.indexOf(activeContentChild);
+      if (index === -1) return;
+
+      // Recalculate positions after resize
+      const { offsetStart: os, offsetEnd: oe, startPosition: sp, endPosition: ep } =
+        calculateScrollAnimationOffset(element);
+      const sr = ep - sp;
+      const targetScrollY = sp + (index * sr) / (children.length - 1);
+
+      isScrollingRef.current = true;
+      callbacksRef.current.onRequestScrollTop?.(targetScrollY, 0, onScrollAnimationFinished);
+    };
+
     window.addEventListener('scroll', handleScroll);
+    window.addEventListener('resize', handleResize);
     return () => {
       window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', handleResize);
       if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current);
     };
   }, [activeContentChild, disabled, children, timeline, hostRef, isPreviewingContentChildren]);

--- a/scrolling-slides/src/hooks/use-view-animation.ts
+++ b/scrolling-slides/src/hooks/use-view-animation.ts
@@ -56,20 +56,28 @@ export function useViewAnimation(
     const containStartScroll = Math.min(rootOffset, rootOffset + containDist);
     const containEndScroll = Math.max(rootOffset, rootOffset + containDist);
 
-    const nearTop = containDist > 0
-      ? rootOffset > 0 && rootOffset < windowHeight
-      : containStartScroll < 0;
-    const nearBottom = containDist > 0
-      ? (scrollHeight - (rootOffset + parentHeight)) > 0 &&
-        (scrollHeight - (rootOffset + parentHeight)) < windowHeight
-      : containEndScroll > maxScroll && maxScroll > 0;
+    const nearTop =
+      containDist > 0 ? rootOffset > 0 && rootOffset < windowHeight : containStartScroll < 0;
+    const nearBottom =
+      containDist > 0
+        ? scrollHeight - (rootOffset + parentHeight) > 0 &&
+          scrollHeight - (rootOffset + parentHeight) < windowHeight
+        : containEndScroll > maxScroll && maxScroll > 0;
 
-    if ((nearTop || nearBottom) && containStartScroll !== containEndScroll) {
+    if (
+      (nearTop || nearBottom) &&
+      parentHeight < window.innerHeight &&
+      containStartScroll !== containEndScroll
+    ) {
       const effectiveScrollStart = nearTop
-        ? (containDist > 0 ? 0 : Math.max(0, containStartScroll))
+        ? containDist > 0
+          ? 0
+          : Math.max(0, containStartScroll)
         : containStartScroll;
       const effectiveScrollEnd = nearBottom
-        ? (containDist > 0 ? maxScroll : Math.min(maxScroll, containEndScroll))
+        ? containDist > 0
+          ? maxScroll
+          : Math.min(maxScroll, containEndScroll)
         : containEndScroll;
       const effectiveRange = effectiveScrollEnd - effectiveScrollStart;
 
@@ -93,7 +101,6 @@ export function useViewAnimation(
     // Calculate percentages
     const percentStart = offsetStart * 100;
     const percentEnd = offsetEnd * 100;
-
     // Type assertion needed because rangeStart/rangeEnd are not yet in KeyframeAnimationOptions types
     const animationOptions = {
       fill: 'both' as const,


### PR DESCRIPTION
## Summary
- Added support for zoom and blur effects on Reveal and Stack slides
- Refactored ScrollSlide to container-translate model
- Fixed scroll zoom sync to align translate timing between adjacent slides
- Various minor tweaks and bug fixes

## Test plan
- [ ] Verify zoom and blur effects work on Reveal and Stack slides
- [ ] Test ScrollSlide container-translate behavior
- [ ] Confirm scroll zoom sync between adjacent slides

🤖 Generated with [Claude Code](https://claude.com/claude-code)