### PR TITLE
Add stop-on-other-play option to video component

### DIFF
--- a/video/src/Video.tsx
+++ b/video/src/Video.tsx
@@ -4,6 +4,8 @@ import { useEditorState, useVevEvent, useDispatchVevEvent, useTracking } from '@
 import { getNameFromUrl, isIE, createTracker } from './utils';
 import { VideoEvent, VideoInteraction } from '.';
 
+const VIDEO_PLAYBACK_EVENT = '@@vev.video.playback';
+
 type Props = {
   video: {
     key: string;
@@ -24,6 +26,7 @@ type Props = {
   preload: 'auto' | 'metadata' | 'none';
   section?: boolean;
   altText?: string;
+  stopOnOtherPlay?: boolean;
 };
 
 const Video = ({
@@ -38,6 +41,7 @@ const Video = ({
   autoplay = false,
   section = false,
   altText,
+  stopOnOtherPlay = false,
 }: Props) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   // Keeps track of the muted state given by interaction events
@@ -148,6 +152,9 @@ const Video = ({
           stateRef.current.maxProgress = stateRef.current.maxProgress;
           break;
         case 'play':
+          window.dispatchEvent(
+            new CustomEvent(VIDEO_PLAYBACK_EVENT, { detail: { source: videoEl } }),
+          );
           dispatchTrackingEvent('VEV_VIDEO_PLAY', {
             videoUrl: video.url,
             videoName: video.name,
@@ -184,6 +191,19 @@ const Video = ({
     evs.forEach((e) => videoEl && videoEl.addEventListener(e, onEv, false));
     return () => evs.forEach((e) => videoEl && videoEl.removeEventListener(e, onEv));
   }, [video, loop, track]);
+
+  useEffect(() => {
+    if (!stopOnOtherPlay) return;
+    const onPlayback = (e: Event) => {
+      const source = (e as CustomEvent).detail?.source;
+      if (source && source !== videoRef.current) {
+        pausedRef.current = true;
+        videoRef.current?.pause();
+      }
+    };
+    window.addEventListener(VIDEO_PLAYBACK_EVENT, onPlayback);
+    return () => window.removeEventListener(VIDEO_PLAYBACK_EVENT, onPlayback);
+  }, [stopOnOtherPlay]);
 
   useEffect(() => {
     const videoEl = videoRef.current;

--- a/video/src/index.ts
+++ b/video/src/index.ts
@@ -29,6 +29,12 @@ registerVevComponent(Video, {
     { name: 'controls', type: 'boolean', initialValue: true },
     { name: 'autoplay', type: 'boolean', initialValue: true },
     { name: 'loop', type: 'boolean' },
+    {
+      name: 'stopOnOtherPlay',
+      type: 'boolean',
+      title: 'Stop on other play',
+      description: 'Stop playback when another video starts playing',
+    },
     { name: 'disableTracking', type: 'boolean' },
     {
       name: 'altText',


### PR DESCRIPTION
## Summary
- Adds a new `stopOnOtherPlay` boolean prop to the Video component that pauses playback when another video starts playing
- Every video broadcasts a window-level custom event on `play`; opted-in videos listen and pause their own playback when the event source is a different element

## Test plan
- [ ] Place two videos on a page, enable `Stop on other play` on one, play the other — the opted-in video pauses
- [ ] Verify that videos without the option continue to play unaffected
- [ ] Verify autoplay/loop/controls behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)