### PR TITLE
Fix reveal directions: add from-bottom, fix from-right (E-1079)

### DIFF
--- a/scrolling-slides/src/components/fields/Transition.tsx
+++ b/scrolling-slides/src/components/fields/Transition.tsx
@@ -141,6 +141,7 @@ const SETTINGS_CONFIG: Record<string, SettingsConfig> = {
           { label: 'From right', value: 'right' },
           { label: 'From left', value: 'left' },
           { label: 'From top', value: 'top' },
+          { label: 'From bottom', value: 'bottom' },
           { label: 'From top left', value: 'top-left' },
           { label: 'From top right', value: 'top-right' },
         ],
@@ -285,8 +286,12 @@ export const BLUR_AMOUNT_MAP: Record<string, number> = {
 };
 
 const REVEAL_CLIP_PATHS: Record<string, string> = {
+  right:
+    'polygon(calc(100% - 100% * var(--slide-offset)) 0, 100% 0, 100% 100%, calc(100% - 100% * var(--slide-offset)) 100%)',
   left: 'polygon(0 0, calc(100% * var(--slide-offset)) 0, calc(100% * var(--slide-offset)) 100%, 0% 100%)',
   top: 'polygon(0 0, 100% 0, 100% calc(var(--slide-offset) * 100%), 0% calc(var(--slide-offset) * 100%))',
+  bottom:
+    'polygon(0 calc(100% - var(--slide-offset) * 100%), 100% calc(100% - var(--slide-offset) * 100%), 100% 100%, 0 100%)',
   'top-left':
     'polygon(-100% -100%, calc((25% + 100% * var(--slide-offset) / 2) * 4) -100%, -100% calc((25% + 100% * var(--slide-offset) / 2) * 4))',
   'top-right':


### PR DESCRIPTION
## Summary
- Adds missing **"From bottom"** option to the reveal transition direction picker.
- Adds the missing **`right`** clip-path. Previously `resolveTransition` had no entry for `right`, so it left `revealDirection` unset and `RevealSlide` fell back to a default polygon identical to `left` — making "From right" and "From left" visually identical.
- Adds the matching **`bottom`** clip-path.

Fixes [E-1079](https://linear.app/vev/issue/E-1079/reveal-is-missing-from-bottom-and-from-right-has-bug).

## Test plan
- [ ] In the editor, pick the Reveal transition and verify "From right" reveals from the right edge (distinct from "From left").
- [ ] Verify the new "From bottom" option reveals from the bottom edge growing upward.
- [ ] Confirm "From left", "From top", "From top left", "From top right" still behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)