### PR TITLE
Fix iOS Safari edge-bleed on idle slider

### DIFF
--- a/slider/src/Slide/Slide.module.css
+++ b/slider/src/Slide/Slide.module.css
@@ -10,6 +10,12 @@
   grid-area: 1/1;
 }
 
+.animated {
+  will-change: transform;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+}
+
 .slide {
   width: 100%;
   margin: 0;

--- a/slider/src/Slide/Slide.tsx
+++ b/slider/src/Slide/Slide.tsx
@@ -127,7 +127,7 @@ export const Slide = ({
       }}
     >
       <div
-        className={styles.wrapper}
+        className={`${styles.wrapper} ${styles.animated}`}
         style={{
           transform: `translate${moveDirection}(${move}%)`,
           transition: `transform ${transitionSpeed}ms ${easing || 'ease'}`,


### PR DESCRIPTION
## Problem

On iOS Safari only, when the auto-scrolling slider goes **idle** (its transform transition settles after a slide move), the parent container's background paints over the slider's left/right edges. While animating it looks fine — the bleed only appears once motion stops.

Root cause is a known WebKit compositing behavior: Safari promotes the slider's animated element to its own GPU layer during the transform transition, then **demotes** that layer once the transition completes. On demotion it repaints, and the editable `:host` background composites on top of the now-uncomposited slide subtree, bleeding over its edges.

The animated element is the inner wrapper in `Slide.tsx` (the one carrying `transition: transform`).

## Fix

CSS-only persistent layer-promotion hint applied **only to the inner animated wrapper** via a dedicated `.animated` class:

```css
.animated {
  will-change: transform;
  -webkit-backface-visibility: hidden;
  backface-visibility: hidden;
}
```

`will-change: transform` doesn't conflict with the element's inline `transform` (a CSS `translateZ(0)` would be overridden by it); `backface-visibility: hidden` is the belt-and-suspenders that keeps Safari from demoting the layer at the animation→idle boundary.

## Why it's safe

Both wrappers share `.wrapper`, so a dedicated modifier class avoids touching the static outer wrapper. The hints create a stacking context only on the inner wrapper — the slides' `zIndex: 0/1` are siblings inside it, so active-slide stacking is unaffected. Only the "slide" variant uses `.animated`; Zoom/Fade/3D/None are untouched.

## Verification

WebKit-specific — won't reproduce in Chrome. On a physical iPhone / iOS Simulator Safari: set a contrasting `:host` background, advance a slide, let the transition settle, and confirm the edges stay clean once idle. Test HORIZONTAL / HORIZONTAL_REVERSE / VERTICAL / VERTICAL_REVERSE and `slidesToLoad > 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)